### PR TITLE
Fix Chromium also on ILK

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ Version 2.4.4 - XX.XX.XXXX (IRQL fork)
 * Minor code cleanup.
 * Expose ARGB as a surface, attempt two.
 * Correctly handle VA_RT_FORMAT_YUV422 in GetSubsamplingFromFormat.
+* Fix Chromium VA-API decoding on ILK (Ironlake) as well
 
 Version 2.4.3 - 12.Mar.2025 (IRQL fork)
 

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -6552,6 +6552,18 @@ i965_QuerySurfaceAttributes(VADriverContextP ctx,
 			attribs[i].value.value.i = VA_FOURCC_I420;
 			i++;
 
+			attribs[i].type = VASurfaceAttribPixelFormat;
+			attribs[i].value.type = VAGenericValueTypeInteger;
+			attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
+			attribs[i].value.value.i = VA_FOURCC_BGRA;
+			i++;
+
+			attribs[i].type = VASurfaceAttribPixelFormat;
+			attribs[i].value.type = VAGenericValueTypeInteger;
+			attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
+			attribs[i].value.value.i = VA_FOURCC_ARGB;
+			i++;
+
 			break;
 
 		default:


### PR DESCRIPTION
I love `i965_QuerySurfaceAttributes` so much, such a beautiful function where everything is one giant mess.

Turns out that I missed out that ILK doesn't have a VPP entrypoint, so I wasn't calling `i965_PopulateVideoProcFormats`.

Hopefully, _this_ fixes that.

(I have another branch that will cleanup the function so my eyes will bleed no more)