### PR TITLE
i965/drv: Allow P010 without HW support once again.

### DIFF
--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -2157,15 +2157,9 @@ i965_CreateSurfaces2(
 		case VA_RT_FORMAT_YUV444:
 		case VA_RT_FORMAT_YUV411:
 		case VA_RT_FORMAT_YUV400:
+		case VA_RT_FORMAT_YUV420_10BPP:
 		case VA_RT_FORMAT_RGB32:
 			break;
-
-		case VA_RT_FORMAT_YUV420_10BPP:
-			/**
-			 * Only allow this format if we support it.
-			 */
-			if (i965->codec_info->has_vpp_p010)
-				break;
 
 		default:
 		{


### PR DESCRIPTION
This was falsely causing mpv (via libavcodec) to print harmless errors even if we have zero support for the format pre-Kaby Lake.

The issue was likely fixed in 3fa80455b8e92a022bdad84166959fa2f488e3f1 by removing the incorrect `VAProfileHEVCMain10` handler for Ivy Bridge/Haswell.