### PR TITLE
Silence multiple warnings.

### DIFF
--- a/src/gen8_post_processing.c
+++ b/src/gen8_post_processing.c
@@ -852,7 +852,7 @@ gen8_pp_plx_avs_initialize(VADriverContextP ctx, struct i965_post_processing_con
 	struct gen7_pp_static_parameter *pp_static_parameter = pp_context->pp_static_parameter;
 	struct gen8_sampler_8x8_avs *sampler_8x8;
 	int i;
-	int width[3], height[3], pitch[3], offset[3];
+	int width[3] = { 0 }, height[3] = { 0 }, pitch[3], offset[3];
 	int src_width, src_height;
 	unsigned char *cc_ptr;
 	AVSState * const avs = &pp_avs_context->state;
@@ -866,6 +866,7 @@ gen8_pp_plx_avs_initialize(VADriverContextP ctx, struct i965_post_processing_con
 	gen8_pp_set_media_rw_message_surface(ctx, pp_context, src_surface, 0, 0,
 										 src_rect,
 										 width, height, pitch, offset);
+
 	src_height = height[0];
 	src_width  = width[0];
 

--- a/src/i965_decoder_utils.c
+++ b/src/i965_decoder_utils.c
@@ -921,7 +921,7 @@ void
 intel_update_vp9_frame_store_index(VADriverContextP ctx,
 								   struct decode_state *decode_state,
 								   VADecPictureParameterBufferVP9 *pic_param,
-								   GenFrameStore frame_store[MAX_GEN_REFERENCE_FRAMES])
+								   GenFrameStore frame_store[MAX_GEN_HCP_REFERENCE_FRAMES])
 {
 	struct object_surface *obj_surface;
 	int i = 0, index = 0;
@@ -969,7 +969,7 @@ intel_update_vp9_frame_store_index(VADriverContextP ctx,
 	}
 
 	//Set the remaining framestores to either last/golden/altref
-	for (i = 3; i < MAX_GEN_REFERENCE_FRAMES; i++) {
+	for (i = 3; i < MAX_GEN_HCP_REFERENCE_FRAMES; i++) {
 		frame_store[i].surface_id = frame_store[i % 2].surface_id;
 		frame_store[i].obj_surface = frame_store[i % 2].obj_surface;
 	}

--- a/src/i965_decoder_utils.h
+++ b/src/i965_decoder_utils.h
@@ -169,7 +169,7 @@ void
 intel_update_vp9_frame_store_index(VADriverContextP ctx,
 								   struct decode_state *decode_state,
 								   VADecPictureParameterBufferVP9 *pic_param,
-								   GenFrameStore frame_store[MAX_GEN_REFERENCE_FRAMES]);
+								   GenFrameStore frame_store[MAX_GEN_HCP_REFERENCE_FRAMES]);
 
 bool
 intel_ensure_vp8_segmentation_buffer(VADriverContextP ctx, GenBuffer *buf,

--- a/src/i965_device_info.c
+++ b/src/i965_device_info.c
@@ -128,9 +128,9 @@ static struct hw_codec_info ilk_hw_codec_info = {
 };
 
 static void gen6_hw_codec_preinit(VADriverContextP ctx, struct hw_codec_info *codec_info);
-static void gen6_get_hw_formats(VADriverContextP ctx, struct object_config *obj_config,
-	struct i965_driver_data* data, int *i, VASurfaceAttrib *attribs);
 
+extern void gen6_get_hw_formats(VADriverContextP ctx, struct object_config *obj_config,
+	struct i965_driver_data* data, int *i, VASurfaceAttrib *attribs);
 extern struct hw_context *gen6_dec_hw_context_init(VADriverContextP, struct object_config *);
 extern struct hw_context *gen6_enc_hw_context_init(VADriverContextP, struct object_config *);
 
@@ -179,11 +179,12 @@ static struct hw_codec_info snb_hw_codec_info = {
 };
 
 static void gen7_hw_codec_preinit(VADriverContextP ctx, struct hw_codec_info *codec_info);
-static void gen7_get_hw_formats(VADriverContextP ctx, struct object_config *obj_config,
-	struct i965_driver_data* data, int *i, VASurfaceAttrib *attribs);
 
+extern void gen7_get_hw_formats(VADriverContextP ctx, struct object_config *obj_config,
+	struct i965_driver_data* data, int *i, VASurfaceAttrib *attribs);
 extern struct hw_context *gen7_dec_hw_context_init(VADriverContextP, struct object_config *);
 extern struct hw_context *gen7_enc_hw_context_init(VADriverContextP, struct object_config *);
+
 static struct hw_codec_info ivb_hw_codec_info = {
 	.dec_hw_context_init = gen7_dec_hw_context_init,
 	.enc_hw_context_init = gen7_enc_hw_context_init,
@@ -296,7 +297,7 @@ extern struct hw_context *gen8_dec_hw_context_init(VADriverContextP, struct obje
 extern struct hw_context *gen8_enc_hw_context_init(VADriverContextP, struct object_config *);
 extern void gen8_post_processing_context_init(VADriverContextP, void *, struct intel_batchbuffer *);
 
-static void gen8_get_hw_formats(VADriverContextP ctx, struct object_config *obj_config,
+extern void gen8_get_hw_formats(VADriverContextP ctx, struct object_config *obj_config,
 	struct i965_driver_data* data, int *i, VASurfaceAttrib *attribs);
 
 static struct hw_codec_info bdw_hw_codec_info = {

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -1162,7 +1162,7 @@ static inline bool expose_frame_level_decoding(struct i965_driver_data *const i9
 	if (!i965->codec_info->supports_short_slice_dec)
 		return false;
 
-	return profile == VAProfileH264Baseline || profile == VAProfileH264ConstrainedBaseline
+	return profile == VAProfileH264ConstrainedBaseline
 		|| profile == VAProfileH264Main || profile == VAProfileH264High;
 }
 

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -2367,7 +2367,6 @@ i965_QueryImageFormats(VADriverContextP ctx,
 	if (!ctx)
 		return VA_STATUS_ERROR_INVALID_CONTEXT;
 
-	struct i965_driver_data *i965 = i965_driver_data(ctx);
 	int n, idx = 0;
 
 	for (n = 0; i965_image_formats_map[n].va_format.fourcc != 0; n++)


### PR DESCRIPTION
This leaves all but one warning in `../intel-vaapi-driver/src/gen9_hevc_encoder.c:2555:62:` as I think GCC is drunk.

~Will merge once I verify that VP9 encoding still works.~