### PR TITLE
Migrate to modern Wayland

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,8 @@ AC_ARG_ENABLE(x11,
 
 AC_ARG_ENABLE([wl-drm],
     [AC_HELP_STRING([--enable-wl-drm],
-                    [build with VA/Wayland API support @<:@default=yes@:>@])],
-    [], [enable_wl_drm="yes"])
+                    [build with legacy VA/Wayland API support @<:@default=no@:>@])],
+    [], [enable_wl_drm="no"])
 
 AC_ARG_ENABLE([hybrid-codec],
     [AC_HELP_STRING([--enable-hybrid-codec],

--- a/configure.ac
+++ b/configure.ac
@@ -52,10 +52,10 @@ AC_ARG_ENABLE(x11,
                     [build with VA/X11 API support @<:@default=yes@:>@])],
     [], [enable_x11="yes"])
 
-AC_ARG_ENABLE([wayland],
-    [AC_HELP_STRING([--enable-wayland],
+AC_ARG_ENABLE([wl-drm],
+    [AC_HELP_STRING([--enable-wl-drm],
                     [build with VA/Wayland API support @<:@default=yes@:>@])],
-    [], [enable_wayland="yes"])
+    [], [enable_wl_drm="yes"])
 
 AC_ARG_ENABLE([hybrid-codec],
     [AC_HELP_STRING([--enable-hybrid-codec],
@@ -165,26 +165,26 @@ AC_MSG_RESULT([$LIBVA_DRIVERS_PATH])
 AC_SUBST(LIBVA_DRIVERS_PATH)
 
 # Check for Wayland
-USE_WAYLAND="no"
-if test "$enable_wayland" = "yes"; then
+USE_LEGACY_WAYLAND="no"
+if test "$enable_wl_drm" = "yes"; then
     PKG_CHECK_MODULES([LIBVA_WAYLAND_DEPS], [libva-wayland >= va_api_version],
         [
           PKG_CHECK_MODULES([WAYLAND_CLIENT],
              [wayland-client >= wayland_api_version],
              [
-                USE_WAYLAND="yes"
+                USE_LEGACY_WAYLAND="yes"
                 WAYLAND_PREFIX=`$PKG_CONFIG --variable=prefix wayland-client`
                 AC_PATH_PROG([WAYLAND_SCANNER], [wayland-scanner],
-                    [USE_ WAYLAND="no"],
+                    [USE_LEGACY_WAYLAND="no"],
                     [${WAYLAND_PREFIX}/bin$PATH_SEPARATOR$PATH])
              ], [:])
         ], [:])
-    if test "$USE_WAYLAND" = "yes"; then
-      AC_DEFINE([HAVE_VA_WAYLAND], [1],
-        [Defined to 1 if VA/Wayland API is enabled])
+    if test "$USE_LEGACY_WAYLAND" = "yes"; then
+      AC_DEFINE([HAVE_VA_LEGACY_WL], [1],
+        [Defined to 1 if the legacy VA/Wayland API is enabled])
     fi
 fi
-AM_CONDITIONAL(USE_WAYLAND, test "$USE_WAYLAND" = "yes")
+AM_CONDITIONAL(USE_LEGACY_WAYLAND, test "$USE_LEGACY_WAYLAND" = "yes")
 
 AC_OUTPUT([
     Makefile
@@ -214,7 +214,7 @@ AC_OUTPUT([
 dnl Print summary
 BACKENDS="drm"
 AS_IF([test "$USE_X11" = "yes"], [BACKENDS="$BACKENDS x11"])
-AS_IF([test "$USE_WAYLAND" = "yes"], [BACKENDS="$BACKENDS wayland"])
+AS_IF([test "$USE_LEGACY_WAYLAND" = "yes"], [BACKENDS="$BACKENDS wl_drm"])
 
 echo
 echo $PACKAGE configuration summary:

--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,7 @@ if get_option('with_x11') != 'no'
 endif
 
 WITH_WAYLAND_LEGACY = false
-if get_option('with_legacy_wayland') != 'no'
+if get_option('with_legacy_wayland')
   wayland_client_dep = dependency(
     'wayland-client',
     version : '>= 1.11.0',

--- a/meson.build
+++ b/meson.build
@@ -72,12 +72,12 @@ if get_option('with_x11') != 'no'
   WITH_X11 = libva_x11_dep.found()
 endif
 
-WITH_WAYLAND = false
-if get_option('with_wayland') != 'no'
+WITH_WAYLAND_LEGACY = false
+if get_option('with_legacy_wayland') != 'no'
   wayland_client_dep = dependency(
     'wayland-client',
     version : '>= 1.11.0',
-    required : get_option('with_wayland') == 'yes')
+    required : get_option('with_legacy_wayland') == 'yes')
 
   if wayland_client_dep.found()
     prefix = wayland_client_dep.get_pkgconfig_variable('prefix')
@@ -87,16 +87,21 @@ if get_option('with_wayland') != 'no'
   endif
 
   wl_scanner = find_program('wayland-scanner', wayland_scanner,
-			    required : get_option('with_wayland') == 'yes')
+			    required : get_option('with_legacy_wayland') == 'yes')
 
   libva_wayland_dep = dependency(
     'libva-wayland',
     version : libva_version,
-    required : get_option('with_wayland') == 'yes')
+    required : get_option('with_legacy_wayland') == 'yes')
 
-  WITH_WAYLAND = (wayland_client_dep.found()
+  libva_modern_dep = dependency('libva',
+    version : '>= 1.22.0',
+    fallback : [ 'libva', 'libva_dep' ])
+
+  WITH_WAYLAND_LEGACY = (wayland_client_dep.found()
 		  and wl_scanner.found()
-		  and libva_wayland_dep.found())
+		  and libva_wayland_dep.found()
+      and !libva_modern_dep.found())
 endif
 
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,10 @@
 option('driverdir', type : 'string', description : 'drivers path')
 option('with_x11', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
-option('with_wayland', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
+option('with_legacy_wayland',
+    description: 'Build with Wayland support via the legacy wl_drm protocol.'
+    type : 'combo',
+    choices : ['yes', 'no', 'auto'],
+    value : 'auto'
+)
 option('enable_hybrid_codec', type : 'boolean', value : false)
 option('enable_tests', type : 'boolean', value : false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,10 +1,10 @@
 option('driverdir', type : 'string', description : 'drivers path')
 option('with_x11', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
 option('with_legacy_wayland',
-    description: 'Build with Wayland support via the legacy wl_drm protocol.'
-    type : 'combo',
-    choices : ['yes', 'no', 'auto'],
-    value : 'auto'
+    description: 'Build with Wayland support via the legacy wl_drm protocol.',
+    deprecated: true,
+    type : 'boolean',
+    value : 'no'
 )
 option('enable_hybrid_codec', type : 'boolean', value : false)
 option('enable_tests', type : 'boolean', value : false)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,7 +76,7 @@ source_c			+= i965_output_x11.c
 source_h			+= i965_output_x11.h
 endif
 
-if USE_WAYLAND
+if USE_LEGACY_WAYLAND
 source_c			+= i965_output_wayland.c
 source_h			+= i965_output_wayland.h
 source_h			+= $(protocol_source_h)
@@ -114,8 +114,8 @@ $(PKG_VERSION_FILE): $(NEW_VERSION_FILE)
 BUILT_SOURCES	+= intel_version.h
 EXTRA_DIST	+= Android.mk intel_version.h.in $(PKG_VERSION_FILE)
 
-# Wayland protocol
-if USE_WAYLAND
+# Wayland via the wl_drm protocol
+if USE_LEGACY_WAYLAND
 protocol_source_h = wayland-drm-client-protocol.h
 i965_output_wayland.c: $(protocol_source_h)
 %-client-protocol.h : %.xml

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -36,7 +36,7 @@
 # include "i965_output_x11.h"
 #endif
 
-#ifdef HAVE_VA_WAYLAND
+#ifdef HAVE_VA_LEGACY_WL
 # include "i965_output_wayland.h"
 #endif
 
@@ -7276,7 +7276,7 @@ struct {
 		0,
 	},
 
-#ifdef HAVE_VA_WAYLAND
+#ifdef HAVE_VA_LEGACY_WL
 	{
 		i965_output_wayland_init,
 		i965_output_wayland_terminate,

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,8 +9,8 @@ config_cfg.set10('HAVE_HYBRID_CODEC', get_option('enable_hybrid_codec'))
 if WITH_X11
   config_cfg.set('HAVE_VA_X11', 1)
 endif
-if WITH_WAYLAND
-  config_cfg.set('HAVE_VA_WAYLAND', 1)
+if WITH_WAYLAND_LEGACY
+  config_cfg.set('HAVE_VA_LEGACY_WL', 1)
 endif
 if cc.has_function('log2f')
   config_cfg.set('HAVE_LOG2F', 1)
@@ -194,7 +194,7 @@ if WITH_X11
   headers += 'i965_output_x11.h'
 endif
 
-if WITH_WAYLAND
+if WITH_WAYLAND_LEGACY
   protocol_header = custom_target(
       'wayland-drm-client-protocol_h',
       output : 'wayland-drm-client-protocol.h',
@@ -228,7 +228,7 @@ if WITH_X11
   shared_deps += [ libva_x11_dep ]
 endif
 
-if WITH_WAYLAND
+if WITH_WAYLAND_LEGACY
   shared_deps += [ wayland_client_dep, libva_wayland_dep ]
 endif
 


### PR DESCRIPTION
Disables the legacy `wl_drm` path since more Wayland compositors are migrating away to `linux-dmabuf`, we can safely just _not_ use our implementation in that case.

Draft until the following is checked:

- [ ] See if it's possible to keep the original `wl_drm` implementation enabled.
- [ ] Check if `wl_drm` only compositors still work using just VA-API only.