### PR TITLE
Final driver changes for 2.4.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,12 +3,12 @@ Copyright (C) 2009-2023 Intel Corporation
 
 Version 2.4.5 - XX.XX.XXXX (IRQL fork)
 
-* Expose RGBX as a VPP format on ILK
-* Expose RGBA/BGRA as a VPP format on ILK
+* Expose ARGB as a VPP format on ILK
 
     Ironlake is affected by the same issue as Sandybridge with
     these formats, meaning that a workaround is needed for Chromium.
 
+* Improvements to ARGB handling in the VPP backend
 * Don't advertise VAProfileHEVCMain10 format support on HSW and IVB.
 * Disable this driver's Wayland backend by default.
 
@@ -17,6 +17,8 @@ Version 2.4.5 - XX.XX.XXXX (IRQL fork)
 
     If any user requires legacy wl_drm support, a build time option
     remains.
+
+* Minor cleanup.
 
 Version 2.4.4 - 06.Apr.2025 (IRQL fork)
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 m4_define([intel_vaapi_driver_major_version], [2])
 m4_define([intel_vaapi_driver_minor_version], [4])
 m4_define([intel_vaapi_driver_micro_version], [5])
-m4_define([intel_vaapi_driver_pre_version],   [1])
+m4_define([intel_vaapi_driver_pre_version],   [0])
 m4_define([intel_vaapi_driver_version],
           [intel_vaapi_driver_major_version.intel_vaapi_driver_minor_version.intel_vaapi_driver_micro_version])
 m4_if(intel_vaapi_driver_pre_version, [0], [], [

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
   'intel-vaapi-driver', 'c',
-  version : '2.4.5.1',
+  version : '2.4.5.0',
   meson_version : '>= 0.43.0',
   default_options : [ 'warning_level=1',
                       'buildtype=debugoptimized' ])

--- a/src/gen6_mfc.c
+++ b/src/gen6_mfc.c
@@ -1325,7 +1325,7 @@ gen6_mfc_avc_pipeline_programing(VADriverContextP ctx,
 	dri_bo *slice_batch_bo;
 
 	if (intel_mfc_interlace_check(ctx, encode_state, encoder_context)) {
-		fprintf(stderr, "Current VA driver don't support interlace mode!\n");
+		i965_log_error(ctx, "Current VA driver don't support interlace mode!\n");
 		assert(0);
 		return;
 	}
@@ -1380,7 +1380,7 @@ gen6_mfc_avc_encode_picture(VADriverContextP ctx,
 				break;
 			} else if (sts == BRC_OVERFLOW_WITH_MIN_QP || sts == BRC_UNDERFLOW_WITH_MAX_QP) {
 				if (!mfc_context->hrd.violation_noted) {
-					fprintf(stderr, "Unrepairable %s!\n", (sts == BRC_OVERFLOW_WITH_MIN_QP) ? "overflow" : "underflow");
+					i965_log_error_nocb("Unrepairable %s!\n", (sts == BRC_OVERFLOW_WITH_MIN_QP) ? "overflow" : "underflow");
 					mfc_context->hrd.violation_noted = 1;
 				}
 				return VA_STATUS_SUCCESS;

--- a/src/gen75_mfc.c
+++ b/src/gen75_mfc.c
@@ -1655,7 +1655,7 @@ gen75_mfc_avc_pipeline_programing(VADriverContextP ctx,
 	dri_bo *slice_batch_bo;
 
 	if (intel_mfc_interlace_check(ctx, encode_state, encoder_context)) {
-		fprintf(stderr, "Current VA driver don't support interlace mode!\n");
+		i965_log_error(ctx, "Current VA driver don't support interlace mode!\n");
 		assert(0);
 		return;
 	}
@@ -1712,7 +1712,7 @@ gen75_mfc_avc_encode_picture(VADriverContextP ctx,
 				break;
 			} else if (sts == BRC_OVERFLOW_WITH_MIN_QP || sts == BRC_UNDERFLOW_WITH_MAX_QP) {
 				if (!mfc_context->hrd.violation_noted) {
-					fprintf(stderr, "Unrepairable %s!\n", (sts == BRC_OVERFLOW_WITH_MIN_QP) ? "overflow" : "underflow");
+					i965_log_error_nocb("Unrepairable %s!\n", (sts == BRC_OVERFLOW_WITH_MIN_QP) ? "overflow" : "underflow");
 					mfc_context->hrd.violation_noted = 1;
 				}
 				return VA_STATUS_SUCCESS;

--- a/src/gen75_picture_process.c
+++ b/src/gen75_picture_process.c
@@ -472,7 +472,7 @@ gen75_proc_picture(VADriverContextP ctx,
 					filter->type != VAProcFilterDeinterlacing        &&
 					filter->type != VAProcFilterSkinToneEnhancement  &&
 					filter->type != VAProcFilterColorBalance) {
-					fprintf(stderr, "Do not support multiply filters outside vebox pipeline \n");
+					i965_log_error(ctx, "Do not support multiply filters outside vebox pipeline \n");
 					assert(0);
 				}
 			}

--- a/src/gen8_mfc.c
+++ b/src/gen8_mfc.c
@@ -1793,7 +1793,7 @@ gen8_mfc_avc_pipeline_programing(VADriverContextP ctx,
 	dri_bo *slice_batch_bo;
 
 	if (intel_mfc_interlace_check(ctx, encode_state, encoder_context)) {
-		fprintf(stderr, "Current VA driver don't support interlace mode!\n");
+		i965_log_error(ctx, "Current VA driver don't support interlace mode!\n");
 		assert(0);
 		return;
 	}
@@ -1850,7 +1850,7 @@ gen8_mfc_avc_encode_picture(VADriverContextP ctx,
 				break;
 			} else if (sts == BRC_OVERFLOW_WITH_MIN_QP || sts == BRC_UNDERFLOW_WITH_MAX_QP) {
 				if (!mfc_context->hrd.violation_noted) {
-					fprintf(stderr, "Unrepairable %s!\n", (sts == BRC_OVERFLOW_WITH_MIN_QP) ? "overflow" : "underflow");
+					i965_log_error_nocb("Unrepairable %s!\n", (sts == BRC_OVERFLOW_WITH_MIN_QP) ? "overflow" : "underflow");
 					mfc_context->hrd.violation_noted = 1;
 				}
 				return VA_STATUS_SUCCESS;
@@ -4579,7 +4579,7 @@ gen8_mfc_vp8_encode_picture(VADriverContextP ctx,
 			gen8_mfc_vp8_hrd_context_update(encode_state, mfc_context);
 		} else if (sts == BRC_OVERFLOW_WITH_MIN_QP || sts == BRC_UNDERFLOW_WITH_MAX_QP) {
 			if (!mfc_context->hrd.violation_noted) {
-				fprintf(stderr, "Unrepairable %s!\n", (sts == BRC_OVERFLOW_WITH_MIN_QP) ? "overflow" : "underflow");
+				i965_log_error_nocb("Unrepairable %s!\n", (sts == BRC_OVERFLOW_WITH_MIN_QP) ? "overflow" : "underflow");
 				mfc_context->hrd.violation_noted = 1;
 			}
 			return VA_STATUS_SUCCESS;

--- a/src/gen8_post_processing.c
+++ b/src/gen8_post_processing.c
@@ -1907,7 +1907,8 @@ gen8_pp_context_get_surface_conf(VADriverContextP ctx,
 		if (fourcc == VA_FOURCC_RGBX ||
 			fourcc == VA_FOURCC_RGBA ||
 			fourcc == VA_FOURCC_BGRX ||
-			fourcc == VA_FOURCC_BGRA) {
+			fourcc == VA_FOURCC_BGRA ||
+			fourcc == VA_FOURCC_ARGB) {
 			/* nothing to do here */
 		} else if (fourcc == VA_FOURCC_P010 || fourcc == VA_FOURCC_NV12) {
 			width[1] = ALIGN(width[0], 2) / 2;
@@ -1938,7 +1939,8 @@ gen8_pp_context_get_surface_conf(VADriverContextP ctx,
 		if (fourcc == VA_FOURCC_RGBX ||
 			fourcc == VA_FOURCC_RGBA ||
 			fourcc == VA_FOURCC_BGRX ||
-			fourcc == VA_FOURCC_BGRA) {
+			fourcc == VA_FOURCC_BGRA ||
+			fourcc == VA_FOURCC_ARGB) {
 			/* nothing to do here */
 		} else if (fourcc == VA_FOURCC_P010 || fourcc == VA_FOURCC_NV12) {
 			width[1] = ALIGN(width[0], 2) / 2;

--- a/src/gen9_mfc_hevc.c
+++ b/src/gen9_mfc_hevc.c
@@ -2535,7 +2535,7 @@ gen9_hcpe_hevc_encode_picture(VADriverContextP ctx,
 				break;
 			} else if (sts == BRC_OVERFLOW_WITH_MIN_QP || sts == BRC_UNDERFLOW_WITH_MAX_QP) {
 				if (!hcpe_context->hrd.violation_noted) {
-					fprintf(stderr, "Unrepairable %s!\n", (sts == BRC_OVERFLOW_WITH_MIN_QP) ? "overflow" : "underflow");
+					i965_log_error_nocb("Unrepairable %s!\n", (sts == BRC_OVERFLOW_WITH_MIN_QP) ? "overflow" : "underflow");
 					hcpe_context->hrd.violation_noted = 1;
 				}
 				return VA_STATUS_SUCCESS;

--- a/src/gen9_post_processing.c
+++ b/src/gen9_post_processing.c
@@ -728,7 +728,8 @@ gen9_pp_context_get_surface_conf(VADriverContextP ctx,
 		if (fourcc == VA_FOURCC_RGBX ||
 			fourcc == VA_FOURCC_RGBA ||
 			fourcc == VA_FOURCC_BGRX ||
-			fourcc == VA_FOURCC_BGRA) {
+			fourcc == VA_FOURCC_BGRA ||
+			fourcc == VA_FOURCC_ARGB) {
 			/* nothing to do here */
 		} else if (fourcc == VA_FOURCC_P010 || fourcc == VA_FOURCC_NV12) {
 			width[1] = ALIGN(width[0], 2) / 2;
@@ -761,7 +762,8 @@ gen9_pp_context_get_surface_conf(VADriverContextP ctx,
 		if (fourcc == VA_FOURCC_RGBX ||
 			fourcc == VA_FOURCC_RGBA ||
 			fourcc == VA_FOURCC_BGRX ||
-			fourcc == VA_FOURCC_BGRA) {
+			fourcc == VA_FOURCC_BGRA ||
+			fourcc == VA_FOURCC_ARGB) {
 			/* nothing to do here */
 		} else if (fourcc == VA_FOURCC_P010 || fourcc == VA_FOURCC_NV12) {
 			width[1] = ALIGN(width[0], 2) / 2;

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -7149,7 +7149,7 @@ void i965_log_info(VADriverContextP ctx, const char *format, ...)
 
 void i965_log_debug(VADriverContextP ctx, const char *format, ...)
 {
-	if (!(g_intel_debug_option_flags & VA_INTEL_DEBUG_VERBOSE))
+	if (!(g_intel_debug_option_flags & INTEL_DEBUG_FLAGS_VERBOSE))
 		return;
 
 	va_list vl;

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -285,17 +285,7 @@ i965_image_formats_map[I965_MAX_IMAGE_FORMATS + 1] = {
 	{
 		/* [31:0] A:R:G:B 8:8:8:8 little endian */
 		I965_SURFACETYPE_RGBA,
-		{ VA_FOURCC_BGRA, VA_LSB_FIRST, 32, 32, 0x00ff0000, 0x0000ff00, 0x000000ff,  0xff000000 }
-	},
-	{
-		/* [31:0] X:B:G:R 8:8:8:8 little endian */
-		I965_SURFACETYPE_RGBA,
-		{ VA_FOURCC_RGBX, VA_LSB_FIRST, 32, 24, 0x000000ff, 0x0000ff00, 0x00ff0000 }
-	},
-	{
-		/* [31:0] X:R:G:B 8:8:8:8 little endian */
-		I965_SURFACETYPE_RGBA,
-		{ VA_FOURCC_BGRX, VA_LSB_FIRST, 32, 24, 0x00ff0000, 0x0000ff00, 0x000000ff }
+		{ VA_FOURCC_BGRA, VA_LSB_FIRST, 32, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000 }
 	},
 	{
 		/* [31:0] A:B:G:R 8:8:8:8 little endian */
@@ -303,10 +293,15 @@ i965_image_formats_map[I965_MAX_IMAGE_FORMATS + 1] = {
 		{ VA_FOURCC_RGBA, VA_LSB_FIRST, 32, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000 }
 	},
 	{
-		/* [31:0] B:G:R:A 8:8:8:8 little endian */
+		/* [31:0] X:R:G:B 8:8:8:8 little endian */
 		I965_SURFACETYPE_RGBA,
-		{ VA_FOURCC_ARGB, VA_LSB_FIRST, 32, 32, 0x0000ff00, 0x00ff0000, 0xff000000, 0x000000ff }
+		{ VA_FOURCC_BGRX, VA_LSB_FIRST, 32, 24, 0x00ff0000, 0x0000ff00, 0x000000ff, 0 }
 	},
+	{
+		/* [31:0] X:B:G:R 8:8:8:8 little endian */
+		I965_SURFACETYPE_RGBA,
+		{ VA_FOURCC_RGBX, VA_LSB_FIRST, 32, 24, 0x000000ff, 0x0000ff00, 0x00ff0000, 0 }
+	}
 };
 
 /* List of supported subpicture formats */
@@ -5257,18 +5252,14 @@ VAStatus i965_DeriveImage(VADriverContextP ctx,
 			image->format.green_mask = 0x0000ff00;
 			image->format.blue_mask = 0x00ff0000;
 			break;
+
 		case VA_FOURCC_BGRA:
 		case VA_FOURCC_BGRX:
+		case VA_FOURCC_ARGB:
 			image->format.red_mask = 0x00ff0000;
 			image->format.green_mask = 0x0000ff00;
 			image->format.blue_mask = 0x000000ff;
-			break;
-
-		case VA_FOURCC_ARGB:
-			image->format.red_mask = 0x0000ff00;
-			image->format.green_mask = 0x00ff0000;
-			image->format.blue_mask = 0xff000000;
-			break;		
+			break;	
 
 		default:
 			goto error;
@@ -5276,21 +5267,17 @@ VAStatus i965_DeriveImage(VADriverContextP ctx,
 
 		switch (image->format.fourcc)
 		{
-
 		case VA_FOURCC_RGBA:
 		case VA_FOURCC_BGRA:
+		case VA_FOURCC_ARGB:
 			image->format.alpha_mask = 0xff000000;
 			image->format.depth = 32;
 			break;
+
 		case VA_FOURCC_RGBX:
 		case VA_FOURCC_BGRX:
 			image->format.alpha_mask = 0x00000000;
 			image->format.depth = 24;
-			break;
-
-		case VA_FOURCC_ARGB:
-			image->format.alpha_mask = 0x000000ff;
-			image->format.depth = 32;
 			break;
 
 		default:
@@ -6332,6 +6319,7 @@ i965_GetSurfaceAttributes(
 						case VA_FOURCC_BGRX:
 						case VA_FOURCC_RGBX:
 						case VA_FOURCC_RGBA:
+						case VA_FOURCC_ARGB:
 							break;
 						default:
 							attrib_list[i].value.value.i = 0;
@@ -6354,6 +6342,7 @@ i965_GetSurfaceAttributes(
 						case VA_FOURCC_BGRX:
 						case VA_FOURCC_RGBX:
 						case VA_FOURCC_RGBA:
+						case VA_FOURCC_ARGB:
 							break;
 						default:
 							attrib_list[i].value.value.i = 0;

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -5875,7 +5875,7 @@ i965_sw_putimage(VADriverContextP ctx,
 		/* Don't allow format mismatch */
 		if (obj_surface->fourcc != obj_image->image.format.fourcc)
 		{
-			fprintf(stderr, "i965_sw_putimage: Format mismatch, rejecting call. (surface: %#010x, image: %#010x)\r\n",
+			i965_log_error(ctx, "i965_sw_putimage: Format mismatch, rejecting call. (surface: %#010x, image: %#010x)\r\n",
 					obj_surface->fourcc, obj_image->image.format.fourcc);
 			return VA_STATUS_ERROR_INVALID_IMAGE_FORMAT;
 		}
@@ -7124,6 +7124,15 @@ void i965_log_error(VADriverContextP ctx, const char *format, ...)
 	va_end(vl);
 }
 
+void i965_log_error_nocb(const char *format, ...)
+{
+	va_list vl;
+
+	va_start(vl, format);
+	vfprintf(stderr, format, vl);
+	va_end(vl);
+}
+
 void i965_log_info(VADriverContextP ctx, const char *format, ...)
 {
 	va_list vl;
@@ -7369,7 +7378,7 @@ i965_initialize_wrapper(VADriverContextP ctx, const char *driver_name)
 	vtable = calloc(1, sizeof(*vtable));
 
 	if (!wrapper_pdrvctx || !vtable) {
-		fprintf(stderr, "Failed to allocate memory for wrapper \n");
+		i965_log_error(ctx, "Failed to allocate memory for wrapper \n");
 		free(wrapper_pdrvctx);
 		free(vtable);
 		return VA_STATUS_ERROR_ALLOCATION_FAILED;
@@ -7390,7 +7399,7 @@ i965_initialize_wrapper(VADriverContextP ctx, const char *driver_name)
 
 		handle = dlopen(driver_path, RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
 		if (!handle) {
-			fprintf(stderr, "failed to open %s\n", driver_path);
+			i965_log_error(ctx, "failed to open %s\n", driver_path);
 			driver_dir = strtok_r(NULL, ":", &saveptr);
 			continue;
 		}
@@ -7426,7 +7435,7 @@ i965_initialize_wrapper(VADriverContextP ctx, const char *driver_name)
 			}
 			if (compatible_versions[i].major < 0) {
 				dlclose(handle);
-				fprintf(stderr, "%s has no function %s\n",
+				i965_log_error(ctx, "%s has no function %s\n",
 						driver_path, init_func_s);
 				driver_dir = strtok_r(NULL, ":", &saveptr);
 				continue;
@@ -7437,7 +7446,7 @@ i965_initialize_wrapper(VADriverContextP ctx, const char *driver_name)
 
 			if (va_status != VA_STATUS_SUCCESS) {
 				dlclose(handle);
-				fprintf(stderr, "%s init failed, got status %i.\n", driver_path, va_status);
+				i965_log_error(ctx, "%s init failed, got status %i.\n", driver_path, va_status);
 				driver_dir = strtok_r(NULL, ":", &saveptr);
 				continue;
 			}

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -7453,7 +7453,7 @@ i965_initialize_wrapper(VADriverContextP ctx, const char *driver_name)
 		i965->wrapper_pdrvctx = wrapper_pdrvctx;
 		return VA_STATUS_SUCCESS;
 	} else {
-		fprintf(stdout, "Not using %s%s\n", driver_name, DRIVER_EXTENSION);
+		i965_log_debug(ctx, "Not using %s%s\n", driver_name, DRIVER_EXTENSION);
 		free(vtable);
 		free(wrapper_pdrvctx);
 		return VA_STATUS_ERROR_OPERATION_FAILED;

--- a/src/i965_drv_video.h
+++ b/src/i965_drv_video.h
@@ -52,7 +52,7 @@
 #define I965_MAX_PROFILES                       20
 #define I965_MAX_ENTRYPOINTS                    7
 #define I965_MAX_CONFIG_ATTRIBUTES              32
-#define I965_MAX_IMAGE_FORMATS                  12
+#define I965_MAX_IMAGE_FORMATS                  11
 #define I965_MAX_SUBPIC_FORMATS                 6
 #define I965_MAX_SUBPIC_SUM                     4
 #define I965_MAX_SURFACE_ATTRIBUTES             32

--- a/src/i965_drv_video.h
+++ b/src/i965_drv_video.h
@@ -682,6 +682,7 @@ i965_destroy_surface_storage(struct object_surface *obj_surface);
 
 // Logging functions for errors (to be shown to users) and info (useful for developers).
 void i965_log_error(VADriverContextP ctx, const char *format, ...);
+void i965_log_error_nocb(const char *format, ...);
 void i965_log_info(VADriverContextP ctx, const char *format, ...);
 void i965_log_debug(VADriverContextP ctx, const char *format, ...);
 

--- a/src/i965_output_x11.c
+++ b/src/i965_output_x11.c
@@ -199,7 +199,7 @@ i965_put_surface_x11(
 		}
 	}
 
-	if (!(g_intel_debug_option_flags & VA_INTEL_DEBUG_OPTION_BENCH))
+	if (!(g_intel_debug_option_flags & INTEL_DEBUG_FLAGS_BENCH))
 		dri_vtable->swap_buffer(ctx, dri_drawable);
 
 	_i965UnlockMutex(&i965->render_mutex);

--- a/src/i965_post_processing.c
+++ b/src/i965_post_processing.c
@@ -1978,7 +1978,8 @@ pp_set_media_rw_message_surface(VADriverContextP ctx, struct i965_post_processin
 	int full_packed_format = (fourcc == VA_FOURCC_RGBA ||
 							  fourcc == VA_FOURCC_RGBX ||
 							  fourcc == VA_FOURCC_BGRA ||
-							  fourcc == VA_FOURCC_BGRX);
+							  fourcc == VA_FOURCC_BGRX ||
+							  fourcc == VA_FOURCC_ARGB);
 	int scale_factor_of_1st_plane_width_in_byte = 1;
 
 	if (surface->type == I965_SURFACE_TYPE_SURFACE) {
@@ -3279,7 +3280,8 @@ gen7_pp_plx_avs_initialize(VADriverContextP ctx, struct i965_post_processing_con
 		if ((src_fourcc == VA_FOURCC_RGBA) ||
 			(src_fourcc == VA_FOURCC_RGBX) ||
 			(src_fourcc == VA_FOURCC_BGRA) ||
-			(src_fourcc == VA_FOURCC_BGRX)) {
+			(src_fourcc == VA_FOURCC_BGRX) ||
+			(src_fourcc == VA_FOURCC_ARGB)) {
 			pp_static_parameter->grf2.avs_wa_enable = 0;
 		}
 	}
@@ -5242,6 +5244,7 @@ i965_image_pl2_processing(VADriverContextP ctx,
 	case VA_FOURCC_BGRA:
 	case VA_FOURCC_RGBX:
 	case VA_FOURCC_RGBA:
+	case VA_FOURCC_ARGB:
 		vaStatus = i965_post_processing_internal(ctx, i965->pp_context,
 												 src_surface,
 												 src_rect,
@@ -5567,6 +5570,7 @@ i965_image_processing(VADriverContextP ctx,
 		case VA_FOURCC_BGRX:
 		case VA_FOURCC_RGBA:
 		case VA_FOURCC_RGBX:
+		case VA_FOURCC_ARGB:
 			status = i965_image_pl1_rgbx_processing(ctx,
 													src_surface,
 													src_rect,
@@ -5788,6 +5792,7 @@ pp_get_kernel_index(uint32_t src_fourcc, uint32_t dst_fourcc, uint32_t pp_ops,
 	case VA_FOURCC_RGBA:
 	case VA_FOURCC_BGRX:
 	case VA_FOURCC_BGRA:
+	case VA_FOURCC_ARGB:
 		switch (dst_fourcc) {
 		case VA_FOURCC_NV12:
 			pp_index = PP_RGBX_LOAD_SAVE_NV12;
@@ -5833,6 +5838,7 @@ pp_get_kernel_index(uint32_t src_fourcc, uint32_t dst_fourcc, uint32_t pp_ops,
 		case VA_FOURCC_RGBA:
 		case VA_FOURCC_BGRX:
 		case VA_FOURCC_BGRA:
+		case VA_FOURCC_ARGB:
 			pp_index = PP_NV12_LOAD_SAVE_RGBX;
 			break;
 		}

--- a/src/intel_common_vpp_internal.c
+++ b/src/intel_common_vpp_internal.c
@@ -201,7 +201,8 @@ intel_common_scaling_post_processing(VADriverContextP ctx,
 	if (dst_fourcc == VA_FOURCC_RGBX ||
 		dst_fourcc == VA_FOURCC_RGBA ||
 		dst_fourcc == VA_FOURCC_BGRX ||
-		dst_fourcc == VA_FOURCC_BGRA)
+		dst_fourcc == VA_FOURCC_BGRA ||
+		dst_fourcc == VA_FOURCC_ARGB)
 		scale_flag |= DST_RGB32;
 
 	/* If P010 is converted without resolution change,

--- a/src/intel_driver.h
+++ b/src/intel_driver.h
@@ -106,15 +106,19 @@ struct intel_batchbuffer;
 #define True 1
 #define False 0
 
+enum intel_debug_flags
+{
+	INTEL_DEBUG_FLAGS_NONE = 0,
+	INTEL_DEBUG_FLAGS_ASSERTS = 1,
+	INTEL_DEBUG_FLAGS_BENCH = 2,
+	INTEL_DEBUG_FLAGS_DUMP_AUB = 4,
+	INTEL_DEBUG_FLAGS_VERBOSE = 8
+};
 extern uint32_t g_intel_debug_option_flags;
-#define VA_INTEL_DEBUG_OPTION_ASSERT    (1 << 0)
-#define VA_INTEL_DEBUG_OPTION_BENCH     (1 << 1)
-#define VA_INTEL_DEBUG_OPTION_DUMP_AUB  (1 << 2)
-#define VA_INTEL_DEBUG_VERBOSE          (1 << 3)
 
 #define ASSERT_RET(value, fail_ret) do {    \
 		if (!(value)) {                     \
-			if (g_intel_debug_option_flags & VA_INTEL_DEBUG_OPTION_ASSERT)       \
+			if (g_intel_debug_option_flags & INTEL_DEBUG_FLAGS_ASSERTS)      \
 				assert(value);              \
 			return fail_ret;                \
 		}                                   \
@@ -122,7 +126,7 @@ extern uint32_t g_intel_debug_option_flags;
 
 #define ASSERT_RET_MUTEX(value, mutex, fail_ret) do {    \
 		if (!(value)) {                     \
-			if (g_intel_debug_option_flags & VA_INTEL_DEBUG_OPTION_ASSERT)       \
+			if (g_intel_debug_option_flags & INTEL_DEBUG_FLAGS_ASSERTS)      \
 				assert(value);              \
 			_i965UnlockMutex(mutex);        \
 			return fail_ret;                \

--- a/src/intel_memman.c
+++ b/src/intel_memman.c
@@ -41,6 +41,10 @@ intel_memman_init(struct intel_driver_data *intel)
 
 	intel_bufmgr_gem_enable_reuse(intel->bufmgr);
 
+	/**
+	 * TODO: Replace this with a local version if possible since the libdrm
+	 * APIs do nothing since 2015.
+	 */
 	if (g_intel_debug_option_flags & INTEL_DEBUG_FLAGS_DUMP_AUB) {
 		drm_intel_bufmgr_gem_set_aub_filename(intel->bufmgr,
 											  "va.aub");

--- a/src/intel_memman.c
+++ b/src/intel_memman.c
@@ -41,7 +41,7 @@ intel_memman_init(struct intel_driver_data *intel)
 
 	intel_bufmgr_gem_enable_reuse(intel->bufmgr);
 
-	if (g_intel_debug_option_flags & VA_INTEL_DEBUG_OPTION_DUMP_AUB) {
+	if (g_intel_debug_option_flags & INTEL_DEBUG_FLAGS_DUMP_AUB) {
 		drm_intel_bufmgr_gem_set_aub_filename(intel->bufmgr,
 											  "va.aub");
 		drm_intel_bufmgr_gem_set_aub_dump(intel->bufmgr, 1);


### PR DESCRIPTION
Final release blockers:

- [x] ~~VP9 encode seems broken....??~~ I blame AMD messing with the `/dev/dri/` order
- [x] Fixing the image format table up made ARGB no-longer function through GStreamer