### PR TITLE
Update intel-vaapi-driver.spec to match the meson options

### DIFF
--- a/distribution/rpm/intel-vaapi-driver.spec
+++ b/distribution/rpm/intel-vaapi-driver.spec
@@ -44,8 +44,7 @@ VA-API (Video Acceleration API) user mode driver for Intel GEN Graphics family (
 %build
 %meson \
   -D enable_hybrid_codec=true \
-  -D with_x11=yes \
-  -D with_wayland=yes
+  -D with_x11=yes
 
 %meson_build
 


### PR DESCRIPTION
Since the meson options has changed, the `intel-vaapi-driver.spec` needs to be adjusted as well.