### PR TITLE
build: Fix automatic opt-out from the wl_drm backend

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,7 @@ if get_option('with_x11') != 'no'
 endif
 
 WITH_WAYLAND_DRM = false
-if get_option('with_wayland_drm')
+if get_option('with_wayland_drm') != 'no'
   wayland_client_dep = dependency(
     'wayland-client',
     version : '>= 1.11.0',
@@ -94,14 +94,22 @@ if get_option('with_wayland_drm')
     version : libva_version,
     required : get_option('with_wayland_drm') == 'yes')
 
-  libva_modern_dep = dependency('libva',
-    version : '>= 1.22.0',
-    fallback : [ 'libva', 'libva_dep' ])
+  # Don't build the wl_drm backend if we're using a
+  # new enough version of libva with dma-buf support.
+  if get_option('with_wayland_drm') == 'auto'
+    libva_modern_dep = dependency('libva',
+      version : '>= 1.22.0',
+      fallback : [ 'libva', 'libva_dep' ])
 
-  WITH_WAYLAND_DRM = (wayland_client_dep.found()
+    WITH_WAYLAND_DRM = (wayland_client_dep.found()
 		  and wl_scanner.found()
 		  and libva_wayland_dep.found()
       and not libva_modern_dep.found())
+  else
+    WITH_WAYLAND_DRM = (wayland_client_dep.found()
+		  and wl_scanner.found()
+		  and libva_wayland_dep.found())
+  endif
 endif
 
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,8 +3,10 @@ option('with_x11', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'aut
 option('with_wayland_drm', 
     description: 'Build with Wayland support via the legacy wl_drm protocol',
     deprecated: true,
-    type : 'boolean',
-    value : false
+    type : 'combo',
+    choices : ['yes', 'no', 'auto'],
+    value : 'auto'
 )
-option('enable_hybrid_codec', type : 'boolean', value : false)
+option('enable_hybrid_codec', type : 'boolean', value : false,
+    description: 'Enables support for loading the separate hybrid codec driver.')
 option('enable_tests', type : 'boolean', value : false)


### PR DESCRIPTION
Previously, we'd always _not_ build the backend if we had a new enough version of LibVA, revert this partially into a choice where only auto does this behaviour, leaving the `yes` and `no` options for the user.

Also pull in a description from the sunset-cnl branch.