### PR TITLE
Revert for Gen6: H264: Use macroblock pair to calculate H264 decoding parameter under MBAFF flag

### DIFF
--- a/src/gen6_mfd.c
+++ b/src/gen6_mfd.c
@@ -563,20 +563,15 @@ gen6_mfd_avc_slice_state(VADriverContextP ctx,
 		num_ref_idx_l1 = 0;
 	}
 
-	first_mb_in_slice = slice_param->first_mb_in_slice;
+	first_mb_in_slice = slice_param->first_mb_in_slice << mbaff_picture;
 	slice_hor_pos = first_mb_in_slice % width_in_mbs;
 	slice_ver_pos = first_mb_in_slice / width_in_mbs;
 
-	if (mbaff_picture)
-		slice_ver_pos = slice_ver_pos << 1;
-
 	if (next_slice_param) {
-		first_mb_in_next_slice = next_slice_param->first_mb_in_slice;
+		first_mb_in_next_slice = next_slice_param->first_mb_in_slice << mbaff_picture;
 		next_slice_hor_pos = first_mb_in_next_slice % width_in_mbs;
 		next_slice_ver_pos = first_mb_in_next_slice / width_in_mbs;
 
-		if (mbaff_picture)
-			next_slice_ver_pos = next_slice_ver_pos << 1;
 	} else {
 		next_slice_hor_pos = 0;
 		next_slice_ver_pos = height_in_mbs;


### PR DESCRIPTION
This partially reverts commit 1a089932922bafe22a6322c7a49ed214a3e65b23.

According to the bug description, the reverted commit fixed MBAFF decoding for CherryView/BSW (Gen8 graphics) platform: https://bugs.freedesktop.org/show_bug.cgi?id=91207

Gen6 does not suffer from the issue the mentioned commit fixed, and the change introduced a regression in video decoding causing GPU freezes when playing MBAFF-encoded video (reproducibility 100%). GPU freeze happens when the video is MBAFF-encoded, it does not matter whether the video is actually interlaced or not.

This PR reverts the changes for Gen6.

With the change reverted, Gen6 decodes MBAFF video correct, without GPU freeze.

## Test

The test was done on laptop ThinkPad X220 with [Core i7-2620M](https://www.intel.com/content/www/us/en/products/sku/52231/intel-core-i72620m-processor-4m-cache-up-to-3-40-ghz/specifications.html) (mobile Sandy Bridge Gen6 GT2).

Test was done with `mpv` command: `time mpv --hwdec=vaapi <video-file>`

Example output:
```sh
time mpv --hwdec=vaapi video_samples/buck_mbaff_bff_1080i.mp4
 (+) Video --vid=1 (*) (h264 1920x1080 60.000fps)
File tags:
 Artist: Blender Foundation 2008, Janus Bager Kristensen 2013
 Comment: Creative Commons Attribution 3.0 - http://bbb3d.renderfarming.net
 Composer: Sacha Goedegebure
 Genre: Animation
 Title: Big Buck Bunny, Sunflower version
Using hardware decoding (vaapi).
VO: [gpu] 1920x1080 vaapi[nv12]
Exiting... (End of file)
1.70user 0.75system 0:15.64elapsed 15%CPU (0avgtext+0avgdata 154552maxresident)k
0inputs+0outputs (0major+19546minor)pagefaults 0swaps
```

Software environment:
* Ubuntu 24.04.3 LTS
* X11 session with `modesetting` driver (DRI3)
* libva2: 2.22.0 installed from [The Questing Quokka](https://launchpad.net/ubuntu/questing/+source/libva) 
* Mesa 25.2.8
* MESA_LOADER_DRIVER_OVERRIDE=crocus

The H264 test cases specified below are successful, there are no GPU hangs or noticeable decoding artifacts:
* progressive
* MBAFF BFF progressive
* MBAFF BFF interlaced
* MBAFF TFF progressive
* MBAFF TFF interlaced
* PAFF BFF progressive
* PAFF BFF interlaced
* PAFF TFF progressive
* PAFF TFF interlaced

Note that on actually interlaced videos there are visible interlacing lines. However, this effect should be related to deinterlace in post-processing, which is not related to the current change.

The progressive videos and MBAFF were generated with `ffmpeg` with `x264` codec.
PAFF was generated with `QSVEnc` with Intel QSV encoder (on a different system).
Encoder parameters: `-profile high -level 4.1 -slices 4 -ref 4`

The sample videos used in tests are available by the link: https://mega.nz/folder/825yEJIK#SngLVYYV6KMipF_DxXv9QA
