### PR TITLE
Make builds on legacy environments work

### DIFF
--- a/src/i965_format_utils.h
+++ b/src/i965_format_utils.h
@@ -195,6 +195,27 @@ static void i965_GuessExpectedFourCC(int format, int *fourcc)
 #ifndef DRM_FORMAT_GR1616
 #define DRM_FORMAT_GR1616    fourcc_code('G', 'R', '3', '2')
 #endif
+#ifndef DRM_FORMAT_XYUV8888
+#define DRM_FORMAT_XYUV8888  fourcc_code('X', 'Y', 'U', 'V')
+#endif
+#ifndef DRM_FORMAT_Y210
+#define DRM_FORMAT_Y210      fourcc_code('Y', '2', '1', '0')
+#endif
+#ifndef DRM_FORMAT_Y216
+#define DRM_FORMAT_Y216      fourcc_code('Y', '2', '1', '6')
+#endif
+#ifndef DRM_FORMAT_Y410
+#define DRM_FORMAT_Y410      fourcc_code('Y', '4', '1', '0')
+#endif
+#ifndef DRM_FORMAT_Y416
+#define DRM_FORMAT_Y416      fourcc_code('Y', '4', '1', '6')
+#endif
+#ifndef DRM_FORMAT_P010
+#define DRM_FORMAT_P010      fourcc_code('P', '0', '1', '0')
+#endif
+#ifndef DRM_FORMAT_P016
+#define DRM_FORMAT_P016      fourcc_code('P', '0', '1', '6')
+#endif
 
 static uint32_t drm_format_of_separate_plane(uint32_t fourcc, int plane)
 {

--- a/src/intel_compiler.h
+++ b/src/intel_compiler.h
@@ -37,6 +37,12 @@
 /**
  * FALLTHROUGH macro
  */
+#if defined(__has_attribute)
+#  define HAS_GCC_FALLTHROUGH   __has_attribute(fallthrough)
+#else
+#  define HAS_GCC_FALLTHROUGH   0
+#endif
+
 #if defined(__has_cpp_attribute) && defined(__clang__)
 /* We do not do the same trick as __has_attribute because parsing
  * clang::fallthrough in the preprocessor fails in GCC. */
@@ -52,7 +58,7 @@
 #elif HAS_CLANG_FALLTHROUGH
 /* Clang++ specific */
 #define FALLTHROUGH [[clang::fallthrough]]
-#elif __has_attribute(fallthrough)
+#elif HAS_GCC_FALLTHROUGH
 /* Non-standard but supported by at least gcc and clang */
 #define FALLTHROUGH __attribute__((fallthrough))
 #else


### PR DESCRIPTION
My cut off point for "that's an actual issue" is ten years or more especially with libva, then it's strictly "that's a you problem".

The first commit is a **one time** exception to that rule.

The second commit is valid as some of the DRM FOURCCs were added _less_ than ten years ago, so this needs to be handled.