### PR TITLE
Fix video decoding on Chromium for ILK and SNB

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,13 @@ Copyright (C) 2009-2023 Intel Corporation
 
 Version 2.4.6 - XX.XX.XXXX (IRQL fork)
 
+* Fully fix video decoding on Ironlake and Sandy Bridge in Chromium
+
+    This comes with some CPU overhead as we need to override the alpha channel
+    in the post-processing buffer for every single frame.
+
+    There are options to avoid this performance penalty.
+
 * Remove support for VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_3 in vaExportSurfaceHandle.
 
     It was using an ugly memory hack to work and there isn't much support or use case for this variant.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a fork with many changes, including but not limited to:
 
-- Functioning Chromium support [✻]
+- Functioning Chromium support
 - Fix JPEG decoding of oddly encoded files on gen7/8 (https://github.com/intel/intel-vaapi-driver/pull/514)
 - fix exporting buffers with 3 planes and `VA_EXPORT_SURFACE_SEPARATE_LAYERS` (https://github.com/intel/intel-vaapi-driver/pull/530)
 - `i965_pci_ids`: Add CFL PCI ID found on Xeon W-1290P (https://github.com/intel/intel-vaapi-driver/pull/548)
@@ -14,8 +14,6 @@ This is a fork with many changes, including but not limited to:
 - Expose ARGB format support. (https://github.com/intel/intel-vaapi-driver/issues/500)
 
 The `NEWS` file contains a more detailed changelog.
-
-[✻] Works on IVB and newer, broken on SNB and ILK (for now)
 
 # Release schedule
 

--- a/src/i965_post_processing.c
+++ b/src/i965_post_processing.c
@@ -31,6 +31,8 @@
 #include <string.h>
 #include <assert.h>
 
+#include <emmintrin.h>
+
 #include "intel_batchbuffer.h"
 #include "intel_driver.h"
 #include "i965_defines.h"
@@ -1142,6 +1144,29 @@ static struct pp_module pp_modules_gen75[] = {
 	},
 
 };
+
+__attribute__((target("sse2"))) static void
+fill_alpha_rows(uint8_t *base, int pixel_width, int height, int byte_pitch)
+{
+	const __m128i alpha = _mm_set1_epi32(0xFF000000);
+
+	for (int y = 0; y < height; y++)
+	{
+		uint32_t *row = (uint32_t *)(base + y * byte_pitch);
+		int x = 0;
+
+		for (; x + 4 <= pixel_width; x += 4)
+		{
+			__m128i v = _mm_load_si128((__m128i *)&row[x]);
+			_mm_stream_si128((__m128i *)&row[x], _mm_or_si128(v, alpha));
+		}
+
+		for (; x < pixel_width; x++)
+			row[x] |= 0xFF000000u;
+	}
+
+	_mm_sfence();
+}
 
 static void
 pp_dndi_frame_store_reset(DNDIFrameStore *fs)
@@ -6008,7 +6033,22 @@ i965_proc_picture_fast(VADriverContextP ctx,
 	proc_context->pp_context.filter_flags = filter_flags;
 	status = i965_post_processing_internal(ctx, &proc_context->pp_context,
 										   &src_surface, &src_rect, &dst_surface, &dst_rect, pp_index, NULL);
+
 	intel_batchbuffer_flush(proc_context->pp_context.batch);
+
+	if (status == VA_STATUS_SUCCESS &&
+		dst_obj_surface->fourcc == VA_FOURCC_BGRA &&
+		(i965->intel.device_info->driver_workarounds &
+		 HW_WORKAROUND_INVALID_RGBX_SHADER_USE))
+	{
+		dri_bo_map(dst_obj_surface->bo, 1);
+		fill_alpha_rows(dst_obj_surface->bo->virtual,
+						dst_obj_surface->width / 4, /* BGRA is four bytes per pixel. */
+						dst_obj_surface->height,
+						dst_obj_surface->width);
+		dri_bo_unmap(dst_obj_surface->bo);
+	}
+
 	return status;
 }
 

--- a/src/intel_driver.h
+++ b/src/intel_driver.h
@@ -194,8 +194,6 @@ struct intel_device_info {
  * formats with alpha in them, causing them to explode horribly.
  * 
  * To be fair this is my fault since I'm the one that exposed BGRA to Chromium.
- * 
- * Currently provides no functionality.
  */
 #define HW_WORKAROUND_INVALID_RGBX_SHADER_USE					(1 << 2)
 	uint32_t driver_workarounds;
@@ -209,7 +207,7 @@ struct intel_device_info {
 	unsigned int is_broxton     : 1; /* gen9 */
 	unsigned int is_kabylake    : 1; /* gen9p5 */
 	unsigned int is_glklake     : 1; /* gen9p5 lp*/
-	unsigned int is_cfllake     : 1;
+	unsigned int is_cfllake     : 1; /* gen10 (unreleased) */
 };
 
 struct intel_driver_data {


### PR DESCRIPTION
I'm not happy about this solution but I think something is zeroing out the alpha channel, either on the post-processing side (shaders) or the kernel itself, once again I'm a software guy, hardware is black magic to me.

For future work I want to see if I can get the blitter engine to do the work for us, as the blitter engine is screaming "I can literally do this for minimal overhead", current efforts are making the GPU upset so I'll get back to that eventually.