### PR TITLE
meson: fix deprecation warnings with modern meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'intel-vaapi-driver', 'c',
   version : '2.4.6.1',
-  meson_version : '>= 0.43.0',
+  meson_version : '>= 0.60.0',
   default_options : [ 'warning_level=1',
                       'buildtype=debugoptimized' ])
 

--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,7 @@ va_api_minor_version = '33'
 driverdir = get_option('driverdir')
 if libva_dep.type_name() == 'pkgconfig'
   if driverdir == ''
-    driverdir = libva_dep.get_pkgconfig_variable('driverdir')
+    driverdir = libva_dep.get_variable(pkgconfig : 'driverdir')
   endif
   va_api_version_array = libva_dep.version().split('.')
   va_api_major_version = va_api_version_array[0]
@@ -80,7 +80,7 @@ if get_option('with_wayland_drm') != 'no'
     required : get_option('with_wayland_drm') == 'yes')
 
   if wayland_client_dep.found()
-    prefix = wayland_client_dep.get_pkgconfig_variable('prefix')
+    prefix = wayland_client_dep.get_variable(pkgconfig : 'prefix')
     wayland_scanner = join_paths(prefix, 'bin', 'wayland-scanner')
   else
     wayland_scanner = ''

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,13 +20,14 @@ config_file = configure_file(
   output : 'config.h',
   configuration : config_cfg)
 
+intel_driver_git_version = intel_vaapi_driver_version
 if git.found()
   git_version = run_command(
-    git, '--git-dir', join_paths(meson.source_root(), '.git'),
-    'describe', '--tags')
-  intel_driver_git_version = git_version.stdout().strip()
-else
-  intel_driver_git_version = intel_vaapi_driver_version
+    git, '--git-dir', join_paths(meson.project_source_root(), '.git'),
+    'describe', '--tags', check : false)
+  if git_version.returncode() == 0
+    intel_driver_git_version = git_version.stdout().strip()
+  endif
 endif
 
 version_cfg = configuration_data()


### PR DESCRIPTION
Building with meson 1.11 emits a batch of deprecation warnings/notices.
This clears all of them (bar the intentional `with_wayland_drm` option
deprecation):

- **Raise `meson_version` to `>= 0.60.0`.** The build already uses the
  `fallback` argument to `dependency()` (added in 0.54.0) and the
  `deprecated` argument to `option()` (added in 0.60.0), so declare a
  minimum that matches the features actually in use.

- **Check the `git describe` return code and use `project_source_root()`.**
  `run_command()` without a `check:` kwarg warns that the default will
  flip to `true` in meson 2.0, and when building from a tarball (git
  present but no `.git`) the describe fails and the embedded version
  string is left empty. Default the version to the project version and
  only override it when describe succeeds. Also replace the deprecated
  `meson.source_root()` with `meson.project_source_root()`.
  Based on Eli Schwartz's original fix in intel/intel-vaapi-driver:
  https://github.com/intel/intel-vaapi-driver/commit/46898dbd124cb3d0172ce3792df837f998925c35

- **Replace `get_pkgconfig_variable()` with `get_variable(pkgconfig : …)`**
  (deprecated since 0.56.0) for the libva `driverdir` and the
  wayland-scanner `prefix` lookups.

No functional change to the driver.
