### PR TITLE
gen9_hevc_encoder: fix array-bounds in brc_update_set_constant

### DIFF
--- a/src/gen9_hevc_encoder.c
+++ b/src/gen9_hevc_encoder.c
@@ -2544,15 +2544,18 @@ gen9_hevc_brc_update_set_constant(VADriverContextP ctx,
 	if (priv_state->picture_coding_type == HEVC_SLICE_I)
 		memset((void *)pdata, 0, GEN9_HEVC_ENC_SKIP_VAL_SIZE);
 	else {
-		gen9_hevc_mbenc_b_mb_enc_curbe_data *curbe_cmd = NULL;
+		gen9_hevc_mbenc_b_mb_enc_curbe_data curbe_cmd;
+		void *curbe_ptr = NULL;
 		int curbe_size = 0;
 
 		gen9_hevc_get_b_mbenc_default_curbe(priv_state->tu_mode,
 											priv_state->picture_coding_type,
-											(void **)&curbe_cmd,
+											&curbe_ptr,
 											&curbe_size);
 
-		idx = curbe_cmd->dw3.block_based_skip_enable ? 1 : 0;
+		memset(&curbe_cmd, 0, sizeof(curbe_cmd));
+		memcpy(&curbe_cmd, curbe_ptr, curbe_size);
+		idx = curbe_cmd.dw3.block_based_skip_enable ? 1 : 0;
 		memcpy((void *)pdata, GEN9_HEVC_ENC_SKIP_THREAD[idx], sizeof(GEN9_HEVC_ENC_SKIP_THREAD[idx]));
 	}
 	pdata += GEN9_HEVC_ENC_SKIP_VAL_SIZE;


### PR DESCRIPTION
gen9_hevc_brc_update_set_constant() pointed a
gen9_hevc_mbenc_b_mb_enc_curbe_data pointer (77 dwords) straight at the 224-byte default B-MBENC curbe table and read curbe_cmd->dw3. GCC -Warray-bounds rightly flags this: the struct type is larger than the backing table, so the deref is partly outside the object (only dw3, within the first 224 bytes, is actually read).

Mirror the normal curbe path: copy the default into a zeroed full-size struct, then read dw3. The computed idx is unchanged.